### PR TITLE
Add `PostTimeout` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Example:
     func Post(event string, data interface{}) error
         Post a notification (arbitrary data) to the specified event
 
+    func PostTimeout(event string, data interface{}, timeout time.Duration) error
+        Post a notification to the specified event using the provided timeout for
+        any output channels that are blocking
+
     func Start(event string, outputChan chan interface{})
         Start observing the specified event via provided output channel
 

--- a/README.md
+++ b/README.md
@@ -44,5 +44,8 @@ Example:
     func Stop(event string, outputChan chan interface{}) error
         Stop observing the specified event on the provided output channel
 
+    func StopAll(event string) error
+        Stop observing the specified event on all channels
+
     func Version() string
         returns the current version

--- a/notify.go
+++ b/notify.go
@@ -33,6 +33,8 @@ import (
 	"time"
 )
 
+const E_NOT_FOUND = "E_NOT_FOUND"
+
 // returns the current version
 func Version() string {
 	return "0.2"
@@ -58,10 +60,11 @@ func Stop(event string, outputChan chan interface{}) error {
 	defer rwMutex.Unlock()
 
 	newArray := make([]chan interface{}, 0)
-	if _, ok := events[event]; !ok {
-		return errors.New("E_NOT_FOUND")
+	outChans, ok := events[event]
+	if !ok {
+		return errors.New(E_NOT_FOUND)
 	}
-	for _, ch := range events[event] {
+	for _, ch := range outChans {
 		if ch != outputChan {
 			newArray = append(newArray, ch)
 		} else {
@@ -78,10 +81,11 @@ func Post(event string, data interface{}) error {
 	rwMutex.RLock()
 	defer rwMutex.RUnlock()
 
-	if _, ok := events[event]; !ok {
-		return errors.New("E_NOT_FOUND")
+	outChans, ok := events[event]
+	if !ok {
+		return errors.New(E_NOT_FOUND)
 	}
-	for _, outputChan := range events[event] {
+	for _, outputChan := range outChans {
 		outputChan <- data
 	}
 
@@ -94,10 +98,11 @@ func PostTimeout(event string, data interface{}, timeout time.Duration) error {
 	rwMutex.RLock()
 	defer rwMutex.RUnlock()
 
-	if _, ok := events[event]; !ok {
-		return errors.New("E_NOT_FOUND")
+	outChans, ok := events[event]
+	if !ok {
+		return errors.New(E_NOT_FOUND)
 	}
-	for _, outputChan := range events[event] {
+	for _, outputChan := range outChans {
 		select {
 		case outputChan <- data:
 		case <-time.After(timeout):

--- a/notify.go
+++ b/notify.go
@@ -76,6 +76,23 @@ func Stop(event string, outputChan chan interface{}) error {
 	return nil
 }
 
+// Stop observing the specified event on all channels
+func StopAll(event string) error {
+	rwMutex.Lock()
+	defer rwMutex.Unlock()
+
+	outChans, ok := events[event]
+	if !ok {
+		return errors.New(E_NOT_FOUND)
+	}
+	for _, ch := range outChans {
+		close(ch)
+	}
+	delete(events, event)
+
+	return nil
+}
+
 // Post a notification (arbitrary data) to the specified event
 func Post(event string, data interface{}) error {
 	rwMutex.RLock()


### PR DESCRIPTION
This patch makes 4 changes:
- Adds `PostTimeout` function that lets you tell go-notify to time out after a specific time duration for output channels that are blocking. 
- Adds `StopAll` function that lets you unregister all channels listening for a given event.
- Moves the `E_NOT_FOUND` error string to a constant so the output string is only specified in a single location.
- Adds an `outChans` variable that is used to store the results of `events[event]`, so the map lookup doesn't have to happen multiple times unnecessarily.

The `PostTimeout` and `StopAll` functions are both particularly useful from within test code, when you might be exercising code that sets up event listeners that are otherwise beyond control of the tests themselves.
